### PR TITLE
test: pix key broken test

### DIFF
--- a/domain/model/pixKey.go
+++ b/domain/model/pixKey.go
@@ -2,9 +2,10 @@ package model
 
 import (
 	"errors"
+	"time"
+
 	"github.com/asaskevich/govalidator"
 	uuid "github.com/satori/go.uuid"
-	"time"
 )
 
 type PixKeyRepositoryInterface interface {
@@ -47,6 +48,7 @@ func NewPixKey(kind string, account *Account, key string) (*PixKey, error) {
 		Kind:    kind,
 		Key:     key,
 		Account: account,
+		AccountID: account.ID,
 		Status:  "active",
 	}
 


### PR DESCRIPTION
Ao validar o AccountID levamos erro, pois hoje ele está como notnull, mas não estamos passando a prop na hora da criação.

Por isso temos dois testes quebrando tanto do pixKey quanto do transaction.

```
AccountID string   `json:"account_id" valid:"notnull"`
```

<img width="1177" alt="Screenshot 2023-10-16 at 17 11 14" src="https://github.com/devfullcycle/imersao15/assets/77127673/f0d38bc5-9fbe-4e38-b710-6b0e9dd6a4b9">
<img width="1165" alt="Screenshot 2023-10-16 at 17 11 39" src="https://github.com/devfullcycle/imersao15/assets/77127673/9ca5786c-93c4-48d4-b3f2-c07ab75adbdb">
