### PR TITLE
feat: fix no modelo de transaction e na ordem da comparação Equal

### DIFF
--- a/domain/model/transaction.go
+++ b/domain/model/transaction.go
@@ -2,9 +2,10 @@ package model
 
 import (
 	"errors"
+	"time"
+
 	"github.com/asaskevich/govalidator"
 	uuid "github.com/satori/go.uuid"
-	"time"
 )
 
 const (
@@ -92,7 +93,7 @@ func (t *Transaction) Confirm() error {
 func (t *Transaction) Cancel(description string) error {
 	t.Status = TransactionError
 	t.UpdatedAt = time.Now()
-	t.Description = description
+	t.CancelDescription = description
 	err := t.isValid()
 	return err
 }

--- a/domain/model/transaction_test.go
+++ b/domain/model/transaction_test.go
@@ -73,8 +73,6 @@ func TestModel_ChangeStatusOfATransaction(t *testing.T) {
 	require.Equal(t, transaction.Status, model.TransactionCompleted)
 
 	transaction.Cancel("Error")
-	require.Equal(t, transaction.Status, model.TransactionError)
-	require.Equal(t, transaction.CancelDescription, "Error")
-
-
+	require.Equal(t,model.TransactionError, transaction.Status )
+	require.Equal(t, "Error", transaction.CancelDescription)
 }


### PR DESCRIPTION
Na função de cancelamento a propriedade alterada deveria ser CancelDescription.

A função require.Equal espera que o valor expected venha antes do actual.