### PR TITLE
Fix Dependency Installation for Cobra Package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get install build-essential protobuf-compiler librdkafka-dev -y && \
     go get google.golang.org/grpc/cmd/protoc-gen-go-grpc && \
     go get google.golang.org/protobuf/cmd/protoc-gen-go && \
-    go get github.com/spf13/cobra/cobra && \
+    go get github.com/spf13/cobra && \
     wget https://github.com/ktr0731/evans/releases/download/0.9.1/evans_linux_amd64.tar.gz && \
     tar -xzvf evans_linux_amd64.tar.gz && \
     mv evans ../bin && rm -f evans_linux_amd64.tar.gz


### PR DESCRIPTION
Adjusted the command to install 'github.com/spf13/cobra' to resolve the issue where Cobra package was not found.